### PR TITLE
[ci] Add benchmarks for PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ matrix:
     language: go
     go: stable
     os: linux
+    script:
       - "bash ./.travis/benchmark.sh"
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,14 @@ os:
   - linux
   - osx
 
+matrix:
+  include:
+    name: "Benchmarks"
+    language: go
+    go: stable
+    os: linux
+      - "bash ./.travis/benchmark.sh"
+
 script:
   - "go build"
   - "go test -v"

--- a/.travis/benchmark.sh
+++ b/.travis/benchmark.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Get utilities
+go get golang.org/x/perf/cmd/benchstat
+
+# Run benchmark against current branch
+go test -run NoTests -bench . -count 5 > /tmp/new
+
+# Run bebchnark against master
+git reset --hard origin/master
+go test -run NoTests -bench . -count 5 > /tmp/master
+
+benchstat /tmp/master /tmp/new

--- a/.travis/benchmark.sh
+++ b/.travis/benchmark.sh
@@ -1,12 +1,21 @@
 #!/bin/bash
+
+if [ "$TRAVIS_PULL_REQUEST" = "false" ]
+    echo "Skipping benchmarks, this is not a pull request"
+    exit
+then
+fi
+
 # Get utilities
 go get golang.org/x/perf/cmd/benchstat
 
 # Run benchmark against current branch
+echo "Running benchmarks on current commit..."
 go test -run NoTests -bench . -count 5 > /tmp/new
 
 # Run bebchnark against master
-git reset --hard origin/master
+git reset --hard $TRAVIS_BRANCH
+echo "Running benchmarks on $TRAVIS_BRANCH branch..."
 go test -run NoTests -bench . -count 5 > /tmp/master
 
 benchstat /tmp/master /tmp/new

--- a/.travis/benchmark.sh
+++ b/.travis/benchmark.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 
 if [ "$TRAVIS_PULL_REQUEST" = "false" ]
+then
     echo "Skipping benchmarks, this is not a pull request"
     exit
-then
+
 fi
 
 # Get utilities


### PR DESCRIPTION
Travis will now have a new job called `Benchmarks` that will run benchmarks on the PR vs benchmarks on the source branch (here `master`) 5 times.
It will then run it against `benchstat`

See example of this PR: https://travis-ci.org/Viq111/kvimd/jobs/467652545
```
name               old time/op    new time/op    delta
HashDiskWrite-2      5.14µs ± 3%    5.58µs ±10%  +8.48%  (p=0.008 n=5+5)
HashDiskRead-2       1.16µs ± 2%    1.52µs ±37%    ~     (p=0.690 n=5+5)
KvimdRandbo-2         361ns ± 0%     355ns ± 1%  -1.55%  (p=0.008 n=5+5)
KvimdWrite-2         6.19µs ± 2%    6.07µs ± 1%  -2.09%  (p=0.032 n=5+5)
KvimdReadSame-2       156ns ±21%     156ns ±21%    ~     (p=1.000 n=5+5)
KvimdReadRandom-2    1.31µs ±16%    1.43µs ±46%    ~     (p=0.686 n=4+4)
ValuesDiskSet-2      35.0ns ± 2%    34.7ns ± 0%    ~     (p=0.143 n=5+4)
ValuesDiskGet-2      34.1ns ± 1%    34.2ns ± 1%    ~     (p=0.841 n=5+5)

name               old speed      new speed      delta
HashDiskWrite-2    4.67MB/s ± 3%  4.32MB/s ± 9%  -7.62%  (p=0.008 n=5+5)
HashDiskRead-2     20.7MB/s ± 2%  17.2MB/s ±33%    ~     (p=0.690 n=5+5)
KvimdRandbo-2       321MB/s ± 0%   327MB/s ± 1%  +1.67%  (p=0.008 n=5+5)
KvimdWrite-2       18.7MB/s ± 2%  19.1MB/s ± 1%  +2.11%  (p=0.032 n=5+5)
KvimdReadSame-2     687MB/s ±63%   685MB/s ±63%    ~     (p=1.000 n=5+5)
KvimdReadRandom-2  73.9MB/s ±92%  69.6MB/s ±94%    ~     (p=0.690 n=5+5)
ValuesDiskSet-2     229MB/s ± 2%   230MB/s ± 0%    ~     (p=0.190 n=5+4)
ValuesDiskGet-2     235MB/s ± 1%   234MB/s ± 1%    ~     (p=0.841 n=5+5)
```