### PR TITLE
[ci] Add benchmarks for PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,15 @@ os:
   - linux
   - osx
 
+matrix:
+  include:
+    name: "Benchmarks"
+    language: go
+    go: stable
+    os: linux
+    script:
+      - "bash ./.travis/benchmark.sh"
+
 script:
   - "go build"
   - "go test -v"

--- a/.travis/benchmark.sh
+++ b/.travis/benchmark.sh
@@ -11,12 +11,14 @@ fi
 go get golang.org/x/perf/cmd/benchstat
 
 # Run benchmark against current branch
-echo "Running benchmarks on current commit..."
-go test -run NoTests -bench . -count 5 > /tmp/new
+echo "Running benchmarks on current branch PR ($TRAVIS_PULL_REQUEST_BRANCH)..."
+time go test -run NoTests -bench . -count 5 > /tmp/new
 
 # Run bebchnark against master
-git reset --hard $TRAVIS_BRANCH
 echo "Running benchmarks on $TRAVIS_BRANCH branch..."
-go test -run NoTests -bench . -count 5 > /tmp/master
+git reset --hard $TRAVIS_BRANCH
+time go test -run NoTests -bench . -count 5 > /tmp/master
 
+echo "#########################################################"
+echo "Results:"
 benchstat /tmp/master /tmp/new

--- a/.travis/benchmark.sh
+++ b/.travis/benchmark.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+if [ "$TRAVIS_PULL_REQUEST" = "false" ]
+then
+    echo "Skipping benchmarks, this is not a pull request"
+    exit
+
+fi
+
+# Get utilities
+go get golang.org/x/perf/cmd/benchstat
+
+# Run benchmark against current branch
+echo "Running benchmarks on current commit..."
+go test -run NoTests -bench . -count 5 > /tmp/new
+
+# Run bebchnark against master
+git reset --hard $TRAVIS_BRANCH
+echo "Running benchmarks on $TRAVIS_BRANCH branch..."
+go test -run NoTests -bench . -count 5 > /tmp/master
+
+benchstat /tmp/master /tmp/new

--- a/.travis/benchmark.sh
+++ b/.travis/benchmark.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 if [ "$TRAVIS_PULL_REQUEST" = "false" ]
 then
@@ -16,8 +17,8 @@ git reset --hard $TRAVIS_BRANCH
 time go test -run NoTests -bench . -count 5 > /tmp/master
 
 # Run benchmark against current branch
-echo "Running benchmarks on current branch PR ($TRAVIS_PULL_REQUEST_BRANCH)..."
-git reset --hard $TRAVIS_PULL_REQUEST_BRANCH
+echo "Running benchmarks on PR branch ($TRAVIS_PULL_REQUEST_BRANCH)..."
+git checkout $TRAVIS_PULL_REQUEST_BRANCH
 time go test -run NoTests -bench . -count 5 > /tmp/new
 
 echo "#########################################################"

--- a/.travis/benchmark.sh
+++ b/.travis/benchmark.sh
@@ -11,15 +11,14 @@ fi
 # Get utilities
 go get golang.org/x/perf/cmd/benchstat
 
+# Run benchmark against current branch
+echo "Running benchmarks on PR branch $(git rev-parse HEAD)..."
+time go test -run NoTests -bench . -count 5 > /tmp/new
+
 # Run bebchnark against master
 echo "Running benchmarks on $TRAVIS_BRANCH branch..."
 git reset --hard $TRAVIS_BRANCH
 time go test -run NoTests -bench . -count 5 > /tmp/master
-
-# Run benchmark against current branch
-echo "Running benchmarks on PR branch ($TRAVIS_PULL_REQUEST_BRANCH)..."
-git checkout $TRAVIS_PULL_REQUEST_BRANCH
-time go test -run NoTests -bench . -count 5 > /tmp/new
 
 echo "#########################################################"
 echo "Results:"

--- a/.travis/benchmark.sh
+++ b/.travis/benchmark.sh
@@ -10,14 +10,15 @@ fi
 # Get utilities
 go get golang.org/x/perf/cmd/benchstat
 
-# Run benchmark against current branch
-echo "Running benchmarks on current branch PR ($TRAVIS_PULL_REQUEST_BRANCH)..."
-time go test -run NoTests -bench . -count 5 > /tmp/new
-
 # Run bebchnark against master
 echo "Running benchmarks on $TRAVIS_BRANCH branch..."
 git reset --hard $TRAVIS_BRANCH
 time go test -run NoTests -bench . -count 5 > /tmp/master
+
+# Run benchmark against current branch
+echo "Running benchmarks on current branch PR ($TRAVIS_PULL_REQUEST_BRANCH)..."
+git reset --hard $TRAVIS_PULL_REQUEST_BRANCH
+time go test -run NoTests -bench . -count 5 > /tmp/new
 
 echo "#########################################################"
 echo "Results:"


### PR DESCRIPTION
Travis will now have a new job called `Benchmarks` that will run benchmarks on the PR vs benchmarks on the source branch (here `master`) 5 times.
It will then run it against `benchstat`

See example of this PR: https://travis-ci.org/Viq111/kvimd/jobs/467661486
```
name               old time/op    new time/op     delta
HashDiskWrite-2      5.02µs ± 2%     5.46µs ± 8%   ~     (p=0.095 n=5+5)
HashDiskRead-2       1.15µs ± 3%     1.12µs ± 2%   ~     (p=0.151 n=5+5)
KvimdRandbo-2         351ns ± 2%      346ns ± 2%   ~     (p=0.071 n=5+5)
KvimdWrite-2         5.86µs ± 4%     5.92µs ± 4%   ~     (p=0.937 n=5+5)
KvimdReadSame-2       151ns ±21%      149ns ±20%   ~     (p=0.738 n=5+5)
KvimdReadRandom-2    1.65µs ±61%   14.54µs ±112%   ~     (p=0.056 n=5+5)
ValuesDiskSet-2      34.7ns ± 2%     34.6ns ± 2%   ~     (p=0.817 n=5+5)
ValuesDiskGet-2      33.1ns ± 1%     33.1ns ± 1%   ~     (p=0.603 n=5+5)

name               old speed      new speed       delta
HashDiskWrite-2    4.79MB/s ± 2%   4.41MB/s ± 9%   ~     (p=0.087 n=5+5)
HashDiskRead-2     20.9MB/s ± 3%   21.4MB/s ± 2%   ~     (p=0.151 n=5+5)
KvimdRandbo-2       330MB/s ± 2%    334MB/s ± 2%   ~     (p=0.095 n=5+5)
KvimdWrite-2       19.8MB/s ± 4%   19.6MB/s ± 3%   ~     (p=0.952 n=5+5)
KvimdReadSame-2     707MB/s ±64%    721MB/s ±64%   ~     (p=0.841 n=5+5)
KvimdReadRandom-2  80.9MB/s ±70%  29.1MB/s ±150%   ~     (p=0.056 n=5+5)
ValuesDiskSet-2     231MB/s ± 2%    233MB/s ± 0%   ~     (p=0.286 n=5+4)
ValuesDiskGet-2     242MB/s ± 1%    241MB/s ± 1%   ~     (p=0.421 n=5+5)
```