### PR TITLE
[main] Add tests here & there

### DIFF
--- a/hash_disk_test.go
+++ b/hash_disk_test.go
@@ -38,7 +38,7 @@ func TestHashDiskWriteRead(t *testing.T) {
 	require.NoError(t, err)
 	defer h.Close()
 
-	for i := 0; i < 100; i++ {
+	for i := 0; i < 10000; i++ {
 		test := generateTestCase()
 		err = h.Set(test.Key, test.V1, test.V2)
 		require.NoError(t, err)

--- a/paths_test.go
+++ b/paths_test.go
@@ -1,0 +1,39 @@
+package kvimd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPathsGetDBNumber(t *testing.T) {
+	t.Run("hash_disk", func(t *testing.T) {
+		n, err := getDBNumber("db1337.hashdisk")
+		require.NoError(t, err)
+		require.Equal(t, n, 1337)
+	})
+	t.Run("values_disk", func(t *testing.T) {
+		n, err := getDBNumber("db4545.valuesdisk")
+		require.NoError(t, err)
+		require.Equal(t, n, 4545)
+	})
+	t.Run("unknown_pattern", func(t *testing.T) {
+		_, err := getDBNumber("random_string.a")
+		require.Equal(t, err, errUnknownPattern)
+	})
+}
+
+func TestPathsCreate(t *testing.T) {
+	t.Run("hash_disk", func(t *testing.T) {
+		s := createHashDiskPath(45)
+		n, err := getDBNumber(s)
+		require.NoError(t, err)
+		require.Equal(t, n, 45)
+	})
+	t.Run("values_disk", func(t *testing.T) {
+		s := createValuesDiskPath(53)
+		n, err := getDBNumber(s)
+		require.NoError(t, err)
+		require.Equal(t, n, 53)
+	})
+}


### PR DESCRIPTION
- [x] [HashDisk] Now test when there is a collision
- [x] [paths] Add tests for int -> string (path creation)
- [x] [paths] Add tests for string -> int (path detection)
- [x] [ValuesDisk] Add test for `Load()`


Fixes: 
- [x] Properly close all previous DB during failure mid-initialization
- [x] Fix #5 