### PR TITLE
[hashdisk] Add some real benchmarks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ os:
   - osx
 
 matrix:
+  allow_failures:
+    - name: "Benchmarks"
+    - name: "Benchmarks extended"
   include:
   - name: "Benchmarks"
     language: go

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,18 @@ os:
 
 matrix:
   include:
-    name: "Benchmarks"
+  - name: "Benchmarks"
     language: go
     go: stable
     os: linux
     script:
       - "bash ./.travis/benchmark.sh"
+  - name: "Benchmarks extended"
+    language: go
+    go: stable
+    os: linux
+    script:
+      - "bash ./.travis/benchmark_extended.sh"
 
 script:
   - "go build"

--- a/.travis/benchmark.sh
+++ b/.travis/benchmark.sh
@@ -13,12 +13,12 @@ go get golang.org/x/perf/cmd/benchstat
 
 # Run benchmark against current branch
 echo "Running benchmarks on PR branch $(git rev-parse HEAD)..."
-time go test -run NoTests -bench . -count 5 > /tmp/new
+time go test -timeout 0 -run NoTests -bench . -count 5 > /tmp/new
 
 # Run bebchnark against master
 echo "Running benchmarks on $TRAVIS_BRANCH branch..."
 git reset --hard $TRAVIS_BRANCH
-time go test -run NoTests -bench . -count 5 > /tmp/master
+time go test -timeout 0 -run NoTests -bench . -count 5 > /tmp/master
 
 echo "#########################################################"
 echo "Results:"

--- a/.travis/benchmark.sh
+++ b/.travis/benchmark.sh
@@ -23,4 +23,4 @@ time go test -timeout 0 -run NoTests -bench . -count 5 > /tmp/master
 echo "#########################################################"
 echo "Results:"
 benchstat /tmp/master /tmp/new | tee /tmp/diff
-go run .travis/pr_commenter.go Benchmarks /tmp/diff
+go run $(pwd)/.travis/pr_commenter.go Benchmarks /tmp/diff

--- a/.travis/benchmark.sh
+++ b/.travis/benchmark.sh
@@ -12,7 +12,8 @@ fi
 go get golang.org/x/perf/cmd/benchstat
 
 # Run benchmark against current branch
-echo "Running benchmarks on PR branch $(git rev-parse HEAD)..."
+export MERGE_COMMIT=$(git rev-parse HEAD)
+echo "Running benchmarks on PR branch ..."
 time go test -timeout 0 -run NoTests -bench . -count 5 > /tmp/new
 
 # Run bebchnark against master
@@ -20,6 +21,7 @@ echo "Running benchmarks on $TRAVIS_BRANCH branch..."
 git reset --hard $TRAVIS_BRANCH
 time go test -timeout 0 -run NoTests -bench . -count 5 > /tmp/master
 
+git reset --hard $MERGE_COMMIT
 echo "#########################################################"
 echo "Results:"
 benchstat /tmp/master /tmp/new | tee /tmp/diff

--- a/.travis/benchmark.sh
+++ b/.travis/benchmark.sh
@@ -22,4 +22,5 @@ time go test -timeout 0 -run NoTests -bench . -count 5 > /tmp/master
 
 echo "#########################################################"
 echo "Results:"
-benchstat /tmp/master /tmp/new
+benchstat /tmp/master /tmp/new | tee /tmp/diff
+go run .travis/pr_commenter.go Benchmarks /tmp/diff

--- a/.travis/benchmark_extended.sh
+++ b/.travis/benchmark_extended.sh
@@ -23,4 +23,4 @@ time EXTENDED_BENCH_FILE=/tmp/master go test -timeout 0 -run TestExtendedBench -
 echo "#########################################################"
 echo "Results:"
 benchstat /tmp/master /tmp/new | tee /tmp/diff
-go run .travis/pr_commenter.go "Extended benchmarks" /tmp/diff
+go run $(pwd)/.travis/pr_commenter.go "Extended benchmarks" /tmp/diff

--- a/.travis/benchmark_extended.sh
+++ b/.travis/benchmark_extended.sh
@@ -22,4 +22,5 @@ time EXTENDED_BENCH_FILE=/tmp/master go test -timeout 0 -run TestExtendedBench -
 
 echo "#########################################################"
 echo "Results:"
-benchstat /tmp/master /tmp/new
+benchstat /tmp/master /tmp/new | tee /tmp/diff
+go run .travis/pr_commenter.go "Extended benchmarks" /tmp/diff

--- a/.travis/benchmark_extended.sh
+++ b/.travis/benchmark_extended.sh
@@ -13,12 +13,12 @@ go get golang.org/x/perf/cmd/benchstat
 
 # Run benchmark against current branch
 echo "Running benchmarks on PR branch $(git rev-parse HEAD)..."
-time EXTENDED_BENCH_FILE=/tmp/new go test -timeout 0 -run TestExtendedBench -v -count 5
+time EXTENDED_BENCH_FILE=/tmp/new go test -timeout 0 -run TestExtendedBench -v
 
 # Run bebchnark against master
 echo "Running benchmarks on $TRAVIS_BRANCH branch..."
 git reset --hard $TRAVIS_BRANCH
-time EXTENDED_BENCH_FILE=/tmp/master go test -timeout 0 -run TestExtendedBench -v -count 5
+time EXTENDED_BENCH_FILE=/tmp/master go test -timeout 0 -run TestExtendedBench -v
 
 echo "#########################################################"
 echo "Results:"

--- a/.travis/benchmark_extended.sh
+++ b/.travis/benchmark_extended.sh
@@ -13,12 +13,12 @@ go get golang.org/x/perf/cmd/benchstat
 
 # Run benchmark against current branch
 echo "Running benchmarks on PR branch $(git rev-parse HEAD)..."
-time EXTENDED_BENCH_FILE=/tmp/new go test -run TestExtendedBench -v -count 5
+time EXTENDED_BENCH_FILE=/tmp/new go test -timeout 0 -run TestExtendedBench -v -count 5
 
 # Run bebchnark against master
 echo "Running benchmarks on $TRAVIS_BRANCH branch..."
 git reset --hard $TRAVIS_BRANCH
-time EXTENDED_BENCH_FILE=/tmp/master go test -run TestExtendedBench -v -count 5
+time EXTENDED_BENCH_FILE=/tmp/master go test -timeout 0 -run TestExtendedBench -v -count 5
 
 echo "#########################################################"
 echo "Results:"

--- a/.travis/benchmark_extended.sh
+++ b/.travis/benchmark_extended.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -e
+
+if [ "$TRAVIS_PULL_REQUEST" = "false" ]
+then
+    echo "Skipping benchmarks, this is not a pull request"
+    exit
+
+fi
+
+# Get utilities
+go get golang.org/x/perf/cmd/benchstat
+
+# Run benchmark against current branch
+echo "Running benchmarks on PR branch $(git rev-parse HEAD)..."
+time EXTENDED_BENCH_FILE=/tmp/new go test -run TestExtendedBench -v -count 5
+
+# Run bebchnark against master
+echo "Running benchmarks on $TRAVIS_BRANCH branch..."
+git reset --hard $TRAVIS_BRANCH
+time EXTENDED_BENCH_FILE=/tmp/master go test -run TestExtendedBench -v -count 5
+
+echo "#########################################################"
+echo "Results:"
+benchstat /tmp/master /tmp/new

--- a/.travis/benchmark_extended.sh
+++ b/.travis/benchmark_extended.sh
@@ -12,7 +12,8 @@ fi
 go get golang.org/x/perf/cmd/benchstat
 
 # Run benchmark against current branch
-echo "Running benchmarks on PR branch $(git rev-parse HEAD)..."
+export MERGE_COMMIT=$(git rev-parse HEAD)
+echo "Running extended benchmarks on PR branch ..."
 time EXTENDED_BENCH_FILE=/tmp/new go test -timeout 0 -run TestExtendedBench -v
 
 # Run bebchnark against master
@@ -20,6 +21,7 @@ echo "Running benchmarks on $TRAVIS_BRANCH branch..."
 git reset --hard $TRAVIS_BRANCH
 time EXTENDED_BENCH_FILE=/tmp/master go test -timeout 0 -run TestExtendedBench -v
 
+git reset --hard $MERGE_COMMIT
 echo "#########################################################"
 echo "Results:"
 benchstat /tmp/master /tmp/new | tee /tmp/diff

--- a/.travis/pr_commenter.go
+++ b/.travis/pr_commenter.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"strings"
+)
+
+func panicOnErr(err error) {
+	if err != nil {
+		panic(err)
+	}
+}
+
+func main() {
+	// Find all env variables
+	token := os.Getenv("GITHUB_COMMENT_TOKEN")
+	if token == "" {
+		fmt.Fprintf(os.Stderr, "GITHUB_COMMENT_TOKEN was not provided")
+		os.Exit(0)
+	}
+	repo := os.Getenv("TRAVIS_REPO_SLUG")
+	if repo == "" {
+		fmt.Fprintf(os.Stderr, "TRAVIS_REPO_SLUG was not provided")
+		os.Exit(0)
+	}
+	pr := os.Getenv("TRAVIS_PULL_REQUEST")
+	if pr == "" {
+		fmt.Fprintf(os.Stderr, "TRAVIS_PULL_REQUEST was not provided")
+		os.Exit(0)
+	}
+	if len(os.Args) < 3 {
+		fmt.Fprintf(os.Stderr, "CLI args were not provided")
+		os.Exit(0)
+	}
+	name := os.Args[1]
+	filePath := os.Args[2]
+	content, err := ioutil.ReadFile(filePath)
+	panicOnErr(err)
+	if content[len(content)-1] == byte('\n') {
+		content = content[:len(content)-1]
+	}
+
+	// Build json
+	b := new(strings.Builder)
+	b.WriteString("<details>\n")
+	b.WriteString(" <summary>" + name + " results </summary>\n\n")
+	b.WriteString("```gf\n")
+	b.WriteString(string(content))
+	b.WriteString("\n```")
+	type jsonStruct struct {
+		Body string `json:"body"`
+	}
+	j := jsonStruct{Body: b.String()}
+	encoded, err := json.Marshal(&j)
+	panicOnErr(err)
+	reader := bytes.NewReader(encoded)
+
+	// Do request
+	url := fmt.Sprintf("https://api.github.com/repos/%s/issues/%v/comments", repo, pr)
+	client := new(http.Client)
+	req, err := http.NewRequest("POST", url, reader)
+	panicOnErr(err)
+	req.Header.Set("Content-Type", "encoding/json")
+	req.Header.Set("Authorization", "token "+token)
+	resp, err := client.Do(req)
+	panicOnErr(err)
+	resp.Body.Close()
+	fmt.Printf("Comment for %s submitted!\n", name)
+}

--- a/hash_disk_bench_test.go
+++ b/hash_disk_bench_test.go
@@ -45,21 +45,24 @@ func benchmarkHashDiskSetWithLoad(t *testing.T, minLoad, maxLoad float64) {
 
 	// Generate keys until we are at minLoad
 	minItems := int(float64(benchFileSize/itemSize) * minLoad)
+	if minItems < 1 {
+		minItems = 1
+	}
+	maxItems := int(float64(benchFileSize/itemSize) * maxLoad)
 	value := make([]byte, keySize)
-	for i := 0; i < minItems; i++ {
+	for i := 1; i < minItems; i++ {
 		binary.LittleEndian.PutUint64(value, uint64(i))
 		h.Set(value, uint32(i), uint32(i)+3)
 	}
 
-	maxItems := int(float64(benchFileSize/itemSize)*maxLoad) - minItems
 	start := time.Now()
 	// Loop
-	for i := minItems; i < minItems+maxItems; i++ {
+	for i := minItems; i < maxItems; i++ {
 		binary.LittleEndian.PutUint64(value, uint64(i))
 		h.Set(value, uint32(i), uint32(i)+3)
 	}
 	elapsed := time.Now().Sub(start)
-	writeExtendedBenchResult(name, maxItems, elapsed, itemSize)
+	writeExtendedBenchResult(name, maxItems-minItems, elapsed, itemSize)
 }
 
 func TestExtendedBenchHashDiskSetLoad(t *testing.T) {
@@ -101,6 +104,9 @@ func benchmarkHashDiskGetWithLoad(t *testing.T, minLoad, maxLoad float64) {
 
 	// Generate keys until we are at maxLoad
 	minItems := int(float64(benchFileSize/itemSize) * minLoad)
+	if minItems < 1 {
+		minItems = 1
+	}
 	maxItems := int(float64(benchFileSize/itemSize) * maxLoad)
 	value := make([]byte, keySize)
 	for i := 1; i < maxItems; i++ {

--- a/hash_disk_bench_test.go
+++ b/hash_disk_bench_test.go
@@ -1,0 +1,81 @@
+package kvimd
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+/*
+A bit of a hacky way to run only-once (b.N=1) benchmarks through tests (so we don't compile
+benchmarks into the main library as well as they wouldn't appear on the doc site).
+We cannot create a separate package because hashDisk is an internal struct (but we still want to
+benchmark it).
+Usage:
+EXTENDED_BENCH_FILE env var must be set to a path where we will write the results
+You can then call all the tests that starts with TestExtendedBench
+Example:
+EXTENDED_BENCH_FILE=/tmp/results go test -run TestExtendedBench
+*/
+
+// Run one iteration of the benchmark, setting from minLoad to maxLoad
+// Return number of keys set
+func benchmarkHashDiskWithLoad(t *testing.T, minLoad, maxLoad float64) {
+	name := fmt.Sprintf("BenchmarkHashDiskWithLoad_%.2f-%.2f", minLoad, maxLoad)
+	itemSize := int64(keySize + 4 + 4) // Key + 2 uint32
+	// Setup
+	dir, err := ioutil.TempDir("", "hashdisk")
+	if err != nil {
+		t.Fatalf("couldn't create the DB: %s", err)
+	}
+	defer os.RemoveAll(dir)
+	path := filepath.Join(dir, "test.hashdisk")
+
+	h, err := newHashDisk(path, benchFileSize)
+	if err != nil {
+		t.Fatalf("couldn't create the DB: %s", err)
+	}
+	defer h.Close()
+	// Forces hashDisk to allow load of up to 1
+	h.MaxSize = benchFileSize
+
+	// Generate keys until we are at minLoad
+	minItems := int(float64(benchFileSize/itemSize) * minLoad)
+	value := make([]byte, keySize)
+	for i := 0; i < minItems; i++ {
+		binary.LittleEndian.PutUint64(value, uint64(i))
+		h.Set(value, uint32(i), uint32(i)+3)
+	}
+
+	maxItems := int(float64(benchFileSize/itemSize)*maxLoad) - minItems
+	start := time.Now()
+	// Loop
+	for i := minItems; i < minItems+maxItems; i++ {
+		binary.LittleEndian.PutUint64(value, uint64(i))
+		h.Set(value, uint32(i), uint32(i)+3)
+	}
+	elapsed := time.Now().Sub(start)
+	writeExtendedBenchResult(name, maxItems, elapsed, itemSize)
+}
+
+func TestExtendedBenchHashDiskSetLoad(t *testing.T) {
+	if !extendedBench {
+		t.Skip()
+	}
+	t.Run("Load_0-0.5", func(t *testing.T) {
+		benchmarkHashDiskWithLoad(t, 0, 0.5)
+	})
+	t.Run("Load_0.7-0.9", func(t *testing.T) {
+		benchmarkHashDiskWithLoad(t, 0.7, 0.9)
+	})
+	t.Run("Load_0.9-0.95", func(t *testing.T) {
+		benchmarkHashDiskWithLoad(t, 0.9, 0.95)
+	})
+	t.Run("Load_0.95-0.99", func(t *testing.T) {
+		benchmarkHashDiskWithLoad(t, 0.95, 0.99)
+	})
+}

--- a/hash_disk_bench_test.go
+++ b/hash_disk_bench_test.go
@@ -24,8 +24,8 @@ EXTENDED_BENCH_FILE=/tmp/results go test -run TestExtendedBench
 
 // Run one iteration of the benchmark, setting from minLoad to maxLoad
 // Return number of keys set
-func benchmarkHashDiskWithLoad(t *testing.T, minLoad, maxLoad float64) {
-	name := fmt.Sprintf("BenchmarkHashDiskWithLoad_%.2f-%.2f", minLoad, maxLoad)
+func benchmarkHashDiskSetWithLoad(t *testing.T, minLoad, maxLoad float64) {
+	name := fmt.Sprintf("BenchmarkHashDiskSetWithLoad_%.2f-%.2f", minLoad, maxLoad)
 	itemSize := int64(keySize + 4 + 4) // Key + 2 uint32
 	// Setup
 	dir, err := ioutil.TempDir("", "hashdisk")
@@ -67,15 +67,75 @@ func TestExtendedBenchHashDiskSetLoad(t *testing.T) {
 		t.Skip()
 	}
 	t.Run("Load_0-0.5", func(t *testing.T) {
-		benchmarkHashDiskWithLoad(t, 0, 0.5)
+		benchmarkHashDiskSetWithLoad(t, 0, 0.5)
 	})
 	t.Run("Load_0.7-0.9", func(t *testing.T) {
-		benchmarkHashDiskWithLoad(t, 0.7, 0.9)
+		benchmarkHashDiskSetWithLoad(t, 0.7, 0.9)
 	})
 	t.Run("Load_0.9-0.95", func(t *testing.T) {
-		benchmarkHashDiskWithLoad(t, 0.9, 0.95)
+		benchmarkHashDiskSetWithLoad(t, 0.9, 0.95)
 	})
 	t.Run("Load_0.95-0.99", func(t *testing.T) {
-		benchmarkHashDiskWithLoad(t, 0.95, 0.99)
+		benchmarkHashDiskSetWithLoad(t, 0.95, 0.99)
+	})
+}
+
+func benchmarkHashDiskGetWithLoad(t *testing.T, minLoad, maxLoad float64) {
+	name := fmt.Sprintf("BenchmarkHashDiskGetWithLoad_%.2f-%.2f", minLoad, maxLoad)
+	itemSize := int64(keySize + 4 + 4) // Key + 2 uint32
+	// Setup
+	dir, err := ioutil.TempDir("", "hashdisk")
+	if err != nil {
+		t.Fatalf("couldn't create the DB: %s", err)
+	}
+	defer os.RemoveAll(dir)
+	path := filepath.Join(dir, "test.hashdisk")
+
+	h, err := newHashDisk(path, benchFileSize)
+	if err != nil {
+		t.Fatalf("couldn't create the DB: %s", err)
+	}
+	defer h.Close()
+	// Forces hashDisk to allow load of up to 1
+	h.MaxSize = benchFileSize
+
+	// Generate keys until we are at maxLoad
+	minItems := int(float64(benchFileSize/itemSize) * minLoad)
+	maxItems := int(float64(benchFileSize/itemSize) * maxLoad)
+	value := make([]byte, keySize)
+	for i := 1; i < maxItems; i++ {
+		binary.LittleEndian.PutUint64(value, uint64(i))
+		h.Set(value, uint32(i), uint32(i)+3)
+	}
+
+	start := time.Now()
+	// Loop
+	for i := minItems; i < maxItems; i++ {
+		binary.LittleEndian.PutUint64(value, uint64(i))
+		_, _, err := h.Get(value)
+		if err != nil {
+			t.Errorf("Got an error on get: %s", err)
+			t.FailNow()
+		}
+	}
+	elapsed := time.Now().Sub(start)
+	writeExtendedBenchResult(name, maxItems-minItems, elapsed, itemSize)
+}
+
+func TestExtendedBenchHashDiskGetLoad(t *testing.T) {
+	if !extendedBench {
+		t.Skip()
+	}
+	t.Run("Load_0-0.5", func(t *testing.T) {
+		benchmarkHashDiskGetWithLoad(t, 0, 0.5)
+	})
+	t.Run("Load_0.7-0.9", func(t *testing.T) {
+		benchmarkHashDiskGetWithLoad(t, 0.7, 0.9)
+	})
+	t.Run("Load_0.9-0.95", func(t *testing.T) {
+		benchmarkHashDiskGetWithLoad(t, 0.9, 0.95)
+	})
+	t.Run("Load_0.95-0.99", func(t *testing.T) {
+		benchmarkHashDiskGetWithLoad(t, 0.95, 0.99)
 	})
 }

--- a/hash_disk_test.go
+++ b/hash_disk_test.go
@@ -128,12 +128,14 @@ func BenchmarkHashDiskWrite(b *testing.B) {
 	}
 	defer h.Close()
 
+	items := int(h.MaxSize - 1) // So we can make sure we never create a new file on benchmark
 	b.SetBytes(keySize + 8)
 	b.ResetTimer()
 	value := make([]byte, keySize)
 	for i := 0; i < b.N; i++ {
-		binary.LittleEndian.PutUint64(value, uint64(i))
-		h.Set(value, uint32(i), uint32(i)+3)
+		j := i % items
+		binary.LittleEndian.PutUint64(value, uint64(j))
+		h.Set(value, uint32(j), uint32(j)+3)
 	}
 }
 
@@ -150,11 +152,13 @@ func BenchmarkHashDiskRead(b *testing.B) {
 	}
 	defer h.Close()
 
+	items := int(h.MaxSize - 1) // So we can make sure we never create a new file on benchmark
 	b.SetBytes(keySize + 8)
 	b.ResetTimer()
 	value := make([]byte, keySize)
 	for i := 1; i < b.N; i++ {
-		binary.LittleEndian.PutUint64(value, uint64(i))
+		j := i % items
+		binary.LittleEndian.PutUint64(value, uint64(j))
 		_, _, err = h.Get(value)
 		if err != ErrKeyNotFound {
 			b.Fatalf("We should not have found any keys, err=%s", err)

--- a/util_test.go
+++ b/util_test.go
@@ -1,6 +1,12 @@
 package kvimd
 
 import (
+	"fmt"
+	"io"
+	"os"
+	"testing"
+	"time"
+
 	randbo_package "github.com/dustin/randbo"
 )
 
@@ -10,5 +16,45 @@ const (
 )
 
 var (
-	randbo = randbo_package.New()
+	randbo              = randbo_package.New()
+	extendedBench       bool
+	extendedBenchWriter io.Writer
 )
+
+/*
+A bit of a hacky way to run only-once (b.N=1) benchmarks through tests (so we don't compile
+benchmarks into the main library as well as they wouldn't appear on the doc site).
+We cannot create a separate package because hashDisk is an internal struct (but we still want to
+benchmark it).
+Usage:
+EXTENDED_BENCH_FILE env var must be set to a path where we will write the results
+You can then call all the tests that starts with TestExtendedBench
+Example:
+EXTENDED_BENCH_FILE=/tmp/results go test -run TestExtendedBench
+*/
+
+func writeExtendedBenchResult(benchName string, N int, T time.Duration, Bytes int64) {
+	r := testing.BenchmarkResult{
+		N:     N,
+		T:     T,
+		Bytes: Bytes,
+	}
+	line := fmt.Sprintf("%s\t%s\n", benchName, r)
+	extendedBenchWriter.Write([]byte(line))
+}
+
+func TestMain(m *testing.M) {
+	extendedBenchPath := os.Getenv("EXTENDED_BENCH_FILE")
+	if extendedBenchPath != "" {
+		// We will execute the extended benchmarks
+		f, err := os.Create(extendedBenchPath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "failed to create extended benchmark file: %s, exiting\n", err)
+			os.Exit(1)
+		}
+		defer f.Close()
+		extendedBenchWriter = f
+		extendedBench = true
+	}
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
# Fixes

- [x] [hashdisk] Do not add another key, if the key already exist (overrides instead)
- [x] [hashdisk] Only add to the totalItems (== increase load) when it's actually a new key

# Benchmarks
- [x] [util] Add ExtendedBench mode that can basically run benchmarks but with fixed `N`
- [x] [hashdisk] Fix existing benchmarks to not create a new file (instead loop around if `b.N` is bigger than the benchmark file size)
- [x] [hashdisk] Add Set benchmark for loads `0-0.5`; `0.7-0.9`, `0.9-0.95`, `0.95-0.99`
- [x] [hashdisk] Add Get benchmark for loads `0-0.5`; `0.7-0.9`, `0.9-0.95`, `0.95-0.99`
- [x] [ci] Add a `Benchmarks extended` job to travis to test those new benchmarks
- [x] Disable Go timeouts for benchmarks