### PR TITLE
[hashdisk] On same key, return instead of override key

### DIFF
--- a/hash_disk.go
+++ b/hash_disk.go
@@ -99,7 +99,7 @@ func (h *hashDisk) Set(value []byte, fileIndex, fileOffset uint32) error {
 		slotValue := h.m[offset : offset+keySize]
 		if bytes.Equal(slotValue, value) {
 			// Found same key, since we are immutable, just return
-			return
+			return nil
 		}
 		if bytes.Equal(slotValue, h.emptyValue) {
 			// Found empty slot


### PR DESCRIPTION
Since we are by definition immutable, we could just return instead of override on already seen keys.
This should give us a perf boost but prevent us from overriding a bad key