### PR TITLE
[benchmarks] Stabilize them

### DIFF
--- a/hash_disk_test.go
+++ b/hash_disk_test.go
@@ -137,6 +137,7 @@ func BenchmarkHashDiskWrite(b *testing.B) {
 		binary.LittleEndian.PutUint64(value, uint64(j))
 		h.Set(value, uint32(j), uint32(j)+3)
 	}
+	b.StopTimer()
 }
 
 func BenchmarkHashDiskRead(b *testing.B) {
@@ -164,4 +165,5 @@ func BenchmarkHashDiskRead(b *testing.B) {
 			b.Fatalf("We should not have found any keys, err=%s", err)
 		}
 	}
+	b.StopTimer()
 }

--- a/kvimd_test.go
+++ b/kvimd_test.go
@@ -166,6 +166,7 @@ func BenchmarkKvimdWrite(b *testing.B) {
 			b.Fatalf("Failed to write err=%s", err)
 		}
 	}
+	b.StopTimer()
 }
 
 func BenchmarkKvimdReadSame(b *testing.B) {
@@ -193,6 +194,7 @@ func BenchmarkKvimdReadSame(b *testing.B) {
 			b.Fatalf("Failed to write err=%s", err)
 		}
 	}
+	b.StopTimer()
 }
 
 func BenchmarkKvimdReadRandom(b *testing.B) {
@@ -227,4 +229,5 @@ func BenchmarkKvimdReadRandom(b *testing.B) {
 			b.Fatalf("Failed to write err=%s", err)
 		}
 	}
+	b.StopTimer() // Because the defer are slow, stop here
 }

--- a/values_disk_test.go
+++ b/values_disk_test.go
@@ -141,6 +141,7 @@ func BenchmarkValuesDiskSet(b *testing.B) {
 			b.Fatalf("failed to set, you probably need to lower your benchmarking time, err=%s", err)
 		}
 	}
+	b.StopTimer()
 }
 
 func BenchmarkValuesDiskGet(b *testing.B) {
@@ -168,4 +169,5 @@ func BenchmarkValuesDiskGet(b *testing.B) {
 	for i := 1; i < b.N; i++ {
 		v.Get(offset)
 	}
+	b.StopTimer()
 }


### PR DESCRIPTION
We defer the closing of the database
We previously didn't stop the timer at the end of the benchmark so it was factoring in the time it took to close the DB.
Now for every benchmark, we stop timer at end of loop, this should make benchmarks way more stable

Should close https://github.com/Viq111/kvimd/issues/13