### PR TITLE
[valuesdisk] On reload, reload latest offset used to know where to continue from

### DIFF
--- a/kvimd.go
+++ b/kvimd.go
@@ -25,6 +25,7 @@ var (
 	ErrInvalidKey  = errors.New("key is not valid")
 	ErrKeyNotFound = errors.New("key was not found in database")
 	ErrNoSpace     = errors.New("no space left in database") // What you usually want to do here is create a new file
+	ErrCorrupted   = errors.New("database seems corrupted")
 )
 
 // DB is a kvimd database.


### PR DESCRIPTION
Close #4

Don't recreate a 1Gb file each time we close / open kvimd, instead continue where we left of in the valuedisk DB